### PR TITLE
A couple of changes to make Madoka build on MacOS

### DIFF
--- a/lib/madoka/file.cc
+++ b/lib/madoka/file.cc
@@ -37,6 +37,9 @@
  #include <sys/types.h>
  #include <sys/stat.h>
  #include <unistd.h>
+ #ifndef MAP_ANONYMOUS
+ # define MAP_ANONYMOUS MAP_ANON
+ #endif
 #endif  // _WIN32
 
 #include <cstring>

--- a/src/timer.h
+++ b/src/timer.h
@@ -15,6 +15,11 @@
  #endif  // _POSIX_TIMERS
 #endif  // WIN32
 
+// No CLOCK_REALTIME on MacOS X.
+#ifndef CLOCK_REALTIME
+ #undef _POSIX_TIMERS
+#endif
+
 namespace madoka {
 
 class Timer {


### PR DESCRIPTION
MacOS has a few weird incompatible parts. This patch gets the library to build and run, at least on my machine.
